### PR TITLE
bitcoinz - sync.js scriptPubKey.type TypeError

### DIFF
--- a/lib/explorer.js
+++ b/lib/explorer.js
@@ -307,7 +307,7 @@ module.exports = {
         loop.next();
       }
     }, function(){
-      if (vout[0].scriptPubKey.type == 'nonstandard') {
+      if (vout.length > 0 && vout[0].scriptPubKey.type == 'nonstandard') {
         if ( arr_vin.length > 0 && arr_vout.length > 0 ) {
           if (arr_vin[0].addresses == arr_vout[0].addresses) {
             //PoS


### PR DESCRIPTION
`node sync.js index reindex` fails due to hidden z-address transactions on bitcoinz blockchain not having transaction output